### PR TITLE
Moved the redis client to use Sentinel Failover

### DIFF
--- a/conf/uniqush-push.conf
+++ b/conf/uniqush-push.conf
@@ -39,8 +39,9 @@ loglevel=standard
 
 [Database]
 engine=redis
-port=0
+port=26379
 name=0
+master=mymaster
 everysec=600
 leastdirty=10
 cachesize=1024

--- a/configparser.go
+++ b/configparser.go
@@ -100,6 +100,10 @@ func LoadDatabaseConfig(cf *conf.ConfigFile) (*db.DatabaseConfig, error) {
 	if err != nil || c.Host == "" {
 		c.Host = "localhost"
 	}
+	c.Master, err = cf.GetString("Database", "master")
+	if err != nil || c.Host == "" {
+		c.Master = "mymaster"
+	}
 	c.Password, err = cf.GetString("Database", "password")
 	if err != nil {
 		c.Password = ""

--- a/db/dbconfig.go
+++ b/db/dbconfig.go
@@ -27,6 +27,7 @@ type DatabaseConfig struct {
 	Engine    string
 	Name      string
 	User      string
+        Master	  string
 	Password  string
 	Host      string
 	Port      int
@@ -63,8 +64,8 @@ func LoadDatabaseConfig(filename string) (conf *DatabaseConfig, err os.Error) {
 */
 
 func (c *DatabaseConfig) String() string {
-	ret := fmt.Sprintf("engine: %v;\nname: %v;\nuser: %v;\npassowrd: %v;\nhost: %v\nport: %d\n",
-		c.Engine, c.Name, c.User, c.Password, c.Host, c.Port)
+	ret := fmt.Sprintf("engine: %v;\nname: %v;\nuser: %v;\nmaster: %v;\npassowrd: %v;\nhost: %v\nport: %d\n",
+		c.Engine, c.Name, c.User, c.Master, c.Password, c.Host, c.Port)
 
 	return ret
 }

--- a/db/pushredisdb.go
+++ b/db/pushredisdb.go
@@ -64,9 +64,11 @@ func newPushRedisDB(c *DatabaseConfig) (*PushRedisDB, error) {
 		c.Name = "0"
 	}
 
-	var option = redis.Options{}
-	option.Addr = fmt.Sprintf("%s:%d", c.Host, c.Port)
-	option.Password = c.Password
+	var option = redis.FailoverOptions{}
+	option.SentinelAddrs = append (option.SentinelAddrs,fmt.Sprintf("%s:%d", c.Host, c.Port))
+	//option.Addr=fmt.Sprintf("%s:%d", c.Host, c.Port)
+	//option.Password = c.Password
+	option.MasterName = c.Master
 
 	var err error
 	option.DB, err = strconv.ParseInt(c.Name, 10, 64)
@@ -75,7 +77,7 @@ func newPushRedisDB(c *DatabaseConfig) (*PushRedisDB, error) {
 		option.DB = 0
 	}
 
-	client = *redis.NewClient(&option)
+	client = *redis.NewFailoverClient(&option)
 
 	ret := new(PushRedisDB)
 	ret.client = &client


### PR DESCRIPTION
Hello Vu,

Some minor changes to the redis code to support failover using Redis sentinels. The client will connect to a Sentinel, and the sentinel will direct the client to the current redis master.

It would probably be worth abstracting the redis/redissentinel code and leave both options available. Maybe with an additional configuration parameter. That would make the code more flexible and allow the uniqush developers to merge it automatically onto the main code branch.
